### PR TITLE
Dockerfile周りを整備

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:1.13-rc-alpine as build-stage
+FROM golang:1.14-alpine as build-stage
 WORKDIR /app
 COPY go.mod .
 COPY go.sum .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+services:
+  keigo_converted_server:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    image: aizu-go-kapro/keigo:latest
+    ports:
+      - 3000:3000
+    restart: always


### PR DESCRIPTION
### 更新内容
- Backend/敬語変換サーバのDockerfileでBuildに使用しているGoのバージョンを`1.13-rc` -> `1.14` に更新
- 将来的にどこかにデプロイすることを考え、`docker-compose.yml` を定義