### PR TITLE
丁寧語変換ロジックのユニットテストを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ Response:
   "converted_body": "私は寿司が食べたいです。"
 }
 ```
+
+**Test convert logic**
+
+Testing the `keigo/models` package.
+```
+go test keigo/models -v -cover
+```

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Request: GET /keigo
 
 ```
 curl --request GET \
-  --url http://localhost:3000/api/v1/keigo \
+  --url 'http://localhost:3000/api/v1/keigo?kind=teinei' \
   --header 'content-type: application/json' \
   --data '{
-  "body": "寿司が食べたい。"
+  "body": "私は寿司が食べたい。"
 }'
 ```
 
@@ -28,6 +28,6 @@ Response:
 
 ```
 {
-  "converted_body": "寿司 が 食べ たい 。 "
+  "converted_body": "私は寿司が食べたいです。"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Response:
 
 **Test convert logic**
 
-Testing the `github.com/aizu-go-kapro/keiGo/backend/models` package.
+Testing all.
 ```
-go test github.com/aizu-go-kapro/keiGo/backend/models -v -cover
+go test ./... -v -cover
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Response:
 
 **Test convert logic**
 
-Testing the `keigo/models` package.
+Testing the `github.com/aizu-go-kapro/keiGo/backend/models` package.
 ```
-go test keigo/models -v -cover
+go test github.com/aizu-go-kapro/keiGo/backend/models -v -cover
 ```

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/ikawaha/kagome v1.11.2
+	github.com/stretchr/testify v1.4.0
 )

--- a/backend/models/teinei_test.go
+++ b/backend/models/teinei_test.go
@@ -1,8 +1,9 @@
 package models
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConvert(t *testing.T) {
@@ -58,6 +59,22 @@ func TestConvert(t *testing.T) {
 	t.Run("文末が「名詞/形容詞詞」のときは「文末+です」に変換されること", func(t *testing.T) {
 		var body string = "私は寿司。"
 		var convertedBody string = "私は寿司です。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("文末が「助詞」のときは「その1つ前を文末として」変換されること", func(t *testing.T) {
+		var body string = "あっちに行こうよ。"
+		var convertedBody string = "あっちに行きましょうよ。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("kagomeの辞書に存在しない語が含まれていても動作すること", func(t *testing.T) {
+		var body string = "隣で酔っててワロタ。"
+		var convertedBody string = "隣で酔っててワロタ。"
 		actualConvertedBody := teinei.Convert(body)
 		assert.Equal(t, convertedBody, actualConvertedBody)
 		t.Logf("convertedBody: %s", actualConvertedBody)

--- a/backend/models/teinei_test.go
+++ b/backend/models/teinei_test.go
@@ -32,6 +32,22 @@ func TestConvert(t *testing.T) {
 		t.Logf("convertedBody: %s", actualConvertedBody)
 	})
 
+	t.Run("文末が「動詞の終止形/サ変」のときは「動詞の連用形+ます」に変換されること", func(t *testing.T) {
+		var body string = "いったん気絶する。"
+		var convertedBody string = "いったん気絶します。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("文末が「動詞の終止形/カ変」のときは「動詞の連用形+ます」に変換されること", func(t *testing.T) {
+		var body string = "外に来る。"
+		var convertedBody string = "外に来ます。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
 	t.Run("文末が「助動詞の断定のだ」のときは「だ→です」に変換されること", func(t *testing.T) {
 		var body string = "私は寿司だ。"
 		var convertedBody string = "私は寿司です。"
@@ -56,9 +72,33 @@ func TestConvert(t *testing.T) {
 		t.Logf("convertedBody: %s", actualConvertedBody)
 	})
 
+	t.Run("文末が「動詞の連用ウ接続+助動詞の推量/意志のう」のときは「動詞の連用形+ましょう」に変換されること", func(t *testing.T) {
+		var body string = "本を読もう。"
+		var convertedBody string = "本を読みましょう。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
 	t.Run("文末が「名詞/形容詞詞」のときは「文末+です」に変換されること", func(t *testing.T) {
 		var body string = "私は寿司。"
 		var convertedBody string = "私は寿司です。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("文末が「動詞+ない」のときは「動詞の連用形+ません」に変換されること", func(t *testing.T) {
+		var body string = "私は学ばない。"
+		var convertedBody string = "私は学ばないです。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("文末が「動詞以外+ない」のときは「ない+です」に変換されること", func(t *testing.T) {
+		var body string = "それじゃない。"
+		var convertedBody string = "それじゃないです。"
 		actualConvertedBody := teinei.Convert(body)
 		assert.Equal(t, convertedBody, actualConvertedBody)
 		t.Logf("convertedBody: %s", actualConvertedBody)
@@ -73,7 +113,7 @@ func TestConvert(t *testing.T) {
 	})
 
 	t.Run("kagomeの辞書に存在しない語が含まれていても動作すること", func(t *testing.T) {
-		var body string = "隣で酔っててワロタ。"
+		var body string = "隣で酔っててワロタ。"
 		var convertedBody string = "隣で酔っててワロタ。"
 		actualConvertedBody := teinei.Convert(body)
 		assert.Equal(t, convertedBody, actualConvertedBody)

--- a/backend/models/teinei_test.go
+++ b/backend/models/teinei_test.go
@@ -1,7 +1,9 @@
 package models
 
-import "testing"
-import "github.com/stretchr/testify/assert"
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 func TestConvert(t *testing.T) {
 	teinei := Teinei{}
@@ -39,7 +41,7 @@ func TestConvert(t *testing.T) {
 
 	t.Run("文末が「動詞の連用タ接続+助動詞の完了/過去/存続のた」のときは「動詞の連用形+まし+た」に変換されること", func(t *testing.T) {
 		var body string = "私は家に着いた。"
-		var convertedBody string = "私は家に着きました"
+		var convertedBody string = "私は家に着きました。"
 		actualConvertedBody := teinei.Convert(body)
 		assert.Equal(t, convertedBody, actualConvertedBody)
 		t.Logf("convertedBody: %s", actualConvertedBody)
@@ -47,7 +49,7 @@ func TestConvert(t *testing.T) {
 
 	t.Run("文末が「動詞の連用タ接続(促音便形)+助動詞の完了/過去/存続のた」のときは「動詞の連用形+まし+た」に変換されること", func(t *testing.T) {
 		var body string = "私は家に帰った。"
-		var convertedBody string = "私は家に帰りました"
+		var convertedBody string = "私は家に帰りました。"
 		actualConvertedBody := teinei.Convert(body)
 		assert.Equal(t, convertedBody, actualConvertedBody)
 		t.Logf("convertedBody: %s", actualConvertedBody)

--- a/backend/models/teinei_test.go
+++ b/backend/models/teinei_test.go
@@ -1,0 +1,63 @@
+package models
+
+import "testing"
+import "github.com/stretchr/testify/assert"
+
+func TestConvert(t *testing.T) {
+	teinei := Teinei{}
+	t.Run("文末が「です」のときは変換されずそのままであること", func(t *testing.T) {
+		var body string = "私は寿司が食べたいです。"
+		var convertedBody string = "私は寿司が食べたいです。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("文末が「ます」のときは変換されずそのままであること", func(t *testing.T) {
+		var body string = "私は寿司を食べます。"
+		var convertedBody string = "私は寿司を食べます。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("文末が「動詞の終止形」のときは「動詞の連用形+ます」に変換されること", func(t *testing.T) {
+		var body string = "私は寿司を食べる。"
+		var convertedBody string = "私は寿司を食べます。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("文末が「助動詞の断定のだ」のときは「だ→です」に変換されること", func(t *testing.T) {
+		var body string = "私は寿司だ。"
+		var convertedBody string = "私は寿司です。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("文末が「動詞の連用タ接続+助動詞の完了/過去/存続のた」のときは「動詞の連用形+まし+た」に変換されること", func(t *testing.T) {
+		var body string = "私は家に着いた。"
+		var convertedBody string = "私は家に着きました"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("文末が「動詞の連用タ接続(促音便形)+助動詞の完了/過去/存続のた」のときは「動詞の連用形+まし+た」に変換されること", func(t *testing.T) {
+		var body string = "私は家に帰った。"
+		var convertedBody string = "私は家に帰りました"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("文末が「名詞/形容詞詞」のときは「文末+です」に変換されること", func(t *testing.T) {
+		var body string = "私は寿司。"
+		var convertedBody string = "私は寿司です。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+}

--- a/backend/models/teinei_test.go
+++ b/backend/models/teinei_test.go
@@ -90,7 +90,7 @@ func TestConvert(t *testing.T) {
 
 	t.Run("文末が「動詞+ない」のときは「動詞の連用形+ません」に変換されること", func(t *testing.T) {
 		var body string = "私は学ばない。"
-		var convertedBody string = "私は学ばないです。"
+		var convertedBody string = "私は学びません。"
 		actualConvertedBody := teinei.Convert(body)
 		assert.Equal(t, convertedBody, actualConvertedBody)
 		t.Logf("convertedBody: %s", actualConvertedBody)
@@ -107,6 +107,14 @@ func TestConvert(t *testing.T) {
 	t.Run("文末が「助詞」のときは「その1つ前を文末として」変換されること", func(t *testing.T) {
 		var body string = "あっちに行こうよ。"
 		var convertedBody string = "あっちに行きましょうよ。"
+		actualConvertedBody := teinei.Convert(body)
+		assert.Equal(t, convertedBody, actualConvertedBody)
+		t.Logf("convertedBody: %s", actualConvertedBody)
+	})
+
+	t.Run("文末が「記号」でないときも動作すること", func(t *testing.T) {
+		var body string = "私は寿司が食べたいです"
+		var convertedBody string = "私は寿司が食べたいです"
 		actualConvertedBody := teinei.Convert(body)
 		assert.Equal(t, convertedBody, actualConvertedBody)
 		t.Logf("convertedBody: %s", actualConvertedBody)


### PR DESCRIPTION
### 更新内容
- 丁寧語変換ロジックのユニットテストを追加 9562561
- APIコールの例を現在の仕様に合わせて修正 0679bc6
- テスト方法についてのドキュメントを追加 e056ac0

### Test convert logic

Testing all.
```
go test ./... -v -cover
```